### PR TITLE
Remote events

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "babel-polyfill": "^6.3.14",
     "debug": "^2.2.0",
+    "debug-electron": "0.0.1",
     "node-uuid": "^1.4.7",
     "pify": "^2.3.0",
     "rx": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "main": "lib/index.js",
   "homepage": "https://github.com/paulcbetts/electron-remote",
   "dependencies": {
-    "babel-polyfill": "^6.3.14",
+    "babel-polyfill": "^6.13.0",
     "debug": "^2.2.0",
     "debug-electron": "0.0.1",
     "node-uuid": "^1.4.7",
@@ -36,20 +36,20 @@
     "xmlhttprequest": "^1.8.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.4.5",
-    "babel-eslint": "^5.0.0-beta6",
-    "babel-plugin-transform-async-to-generator": "^6.7.4",
-    "babel-plugin-transform-runtime": "^6.7.5",
+    "babel-cli": "^6.11.4",
+    "babel-eslint": "^6.1.2",
+    "babel-plugin-transform-async-to-generator": "^6.8.0",
+    "babel-plugin-transform-runtime": "^6.12.0",
     "babel-preset-es2016-node5": "^1.1.2",
-    "babel-register": "^6.4.3",
-    "chai": "^3.4.1",
-    "chai-as-promised": "^5.2.0",
-    "cross-env": "^1.0.7",
-    "electron-mocha": "^1.2.2",
-    "electron-prebuilt-compile": "^1.1.2",
-    "esdoc": "^0.4.3",
+    "babel-register": "^6.11.6",
+    "chai": "^3.5.0",
+    "chai-as-promised": "^5.3.0",
+    "cross-env": "^2.0.0",
+    "electron-mocha": "^3.0.0",
+    "electron-prebuilt-compile": "1.2.7",
+    "esdoc": "^0.4.8",
     "esdoc-es7-plugin": "0.0.3",
     "esdoc-plugin-async-to-sync": "^0.5.0",
-    "eslint": "^1.10.3"
+    "eslint": "^3.2.2"
   }
 }

--- a/src/execute-js-func.js
+++ b/src/execute-js-func.js
@@ -7,7 +7,7 @@ const responseChannel = 'execute-javascript-response';
 let isBrowser = (process.type === 'browser');
 let ipc = require('electron')[isBrowser ? 'ipcMain' : 'ipcRenderer'];
 
-const d = require(isBrowser ? 'debug' : 'debug/browser')('electron-remote:execute-js-func');
+const d = require('debug-electron')('electron-remote:execute-js-func');
 const BrowserWindow = isBrowser ?
   require('electron').BrowserWindow :
   require('electron').remote.BrowserWindow;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import * as executeJsFunc from './execute-js-func';
 import * as rendererRequire from './renderer-require';
+import * as remoteEvent from './remote-event';
 
 const executeJsFuncExports = [
   'createProxyForRemote',
@@ -15,5 +16,6 @@ const executeJsFuncExports = [
 
 module.exports = Object.assign(
   executeJsFuncExports.reduce((acc, x) => { acc[x] = executeJsFunc[x]; return acc; }, {}),
-  rendererRequire
+  rendererRequire,
+  remoteEvent
 );

--- a/src/remote-event-browser.js
+++ b/src/remote-event-browser.js
@@ -1,0 +1,52 @@
+import {BrowserWindow, ipcMain} from 'electron';
+import {Observable} from 'rx';
+
+const eventListenerTable = {};
+
+function initialize() {
+  ipcMain.on('electron-remote-event-subscribe', (e, x) => {
+    const {type, id, event} = x;
+    let target = null;
+    
+    switch(type) {
+    case 'window':
+      target = BrowserWindow.fromId(id);
+      break;
+    default:
+      target = null;
+    }
+    
+    if (!target) {
+      event.returnValue = {error: `Failed to find ${type} with ID ${id}`};
+      return;
+    }
+    
+    const key = `${type}-${id}-${event}-${e.sender.id}`;
+    if (eventListenerTable[key]) {
+      eventListenerTable[key].refCount++;
+      event.returnValue = {error: null};
+      return;
+    }
+    
+    let targetWebContents = e.sender;
+    
+    eventListenerTable[key] = {
+      refCount: 1,
+      disposable: Observable.fromEvent(target, event, (...args) => [args])
+        .takeUntil(Observable.fromEvent(targetWebContents, 'destroyed'))
+        .subscribe((args) => targetWebContents.send(`electron-remote-event-${key}`, args))
+    };
+  });
+  
+  ipcMain.on('electron-remote-event-dispose', (e, key) => {
+    eventListenerTable[key].refCount--;
+    if (eventListenerTable[key].refCount <= 0) {
+      let k = eventListenerTable[key];
+      delete eventListenerTable[k];
+      
+      k.disposable.dispose();
+    }
+  });
+}
+
+initialize();

--- a/src/remote-event.js
+++ b/src/remote-event.js
@@ -5,14 +5,17 @@ remote.require(require.resolve('./remote-event-browser'));
 
 const d = require('debug-electron')('remote-event');
 
-export function fromRemoteWindow(browserWindow, event) {
+export function fromRemoteWindow(browserWindow, event, onWebContents=false) {
   let type = 'window';
   let id = browserWindow.id;
   
   const key = `electron-remote-event-${type}-${id}-${event}-${remote.getCurrentWebContents().id}`;
   
   d(`Subscribing to event with key: ${key}`);
-  let {error} = ipcRenderer.sendSync('electron-remote-event-subscribe', {type, id, event});
+  let {error} = ipcRenderer.sendSync(
+    'electron-remote-event-subscribe', 
+    {type, id, event, onWebContents});
+  
   if (error) {
     d(`Failed with error: ${error}`);
     return Observable.throw(new Error(error));

--- a/src/remote-event.js
+++ b/src/remote-event.js
@@ -5,6 +5,19 @@ remote.require(require.resolve('./remote-event-browser'));
 
 const d = require('debug-electron')('remote-event');
 
+/**
+ * Safely subscribes to an event on a BrowserWindow or its WebContents. This
+ * method avoids the "remote event listener" Electron issue.
+ *
+ * @param browserWindow  BrowserWindow   - the window to listen to
+ * @param event  String  - The event to listen to
+ * @param onWebContents  Boolean  - If true, the event is on the window's
+ *                                  WebContents, not on the window itself.
+ *
+ * @returns Observable<Object>  - an Observable representing the event.
+ *                                Unsubscribing from the Observable will
+ *                                remove the event listener.
+ */
 export function fromRemoteWindow(browserWindow, event, onWebContents=false) {
   let type = 'window';
   let id = browserWindow.id;

--- a/src/remote-event.js
+++ b/src/remote-event.js
@@ -1,7 +1,7 @@
 import {remote, ipcRenderer} from 'electron';
 import {CompositeDisposable, Disposable, Observable} from 'rx';
 
-remote.require('./remote-event-browser');
+remote.require(require.resolve('./remote-event-browser'));
 
 export function fromRemoteWindow(browserWindow, event) {
   let type = 'window';

--- a/src/remote-event.js
+++ b/src/remote-event.js
@@ -1,0 +1,30 @@
+import {remote, ipcRenderer} from 'electron';
+import {CompositeDisposable, Disposable, Observable} from 'rx';
+
+remote.require('./remote-event-browser');
+
+export function fromRemoteWindow(browserWindow, event) {
+  let type = 'window';
+  let id = browserWindow.id;
+  
+  const key = `electron-remote-event-${type}-${id}-${event}-${remote.getCurrentWebContents().id}`;
+  let {error} = ipcRenderer.sendSync('electron-remote-event-subscribe', {type, id, event});
+  if (error) {
+    return Observable.throw(new Error(error));
+  }
+  
+  let ret = Observable.create((subj) => {
+    let disp = new CompositeDisposable();
+    disp.add(
+      Observable.fromEvent(ipcRenderer, key, (e,arg) => arg)
+        .subscribe(subj));
+      
+    disp.add(Disposable.create(() => {
+      ipcRenderer.send('electron-remote-event-dispose', key);
+    }));
+    
+    return disp;
+  });
+  
+  return ret.publish().refCount();
+}

--- a/src/renderer-require-preload.html
+++ b/src/renderer-require-preload.html
@@ -1,10 +1,10 @@
 <html>
-<head>
-</head>
-<body>
-</body>
+  <head>
+  </head>
+  <body>
+  </body>
 
-<script>
-require('./renderer-require-preload')
-</script>
+  <script>
+    require('./renderer-require-preload')
+  </script>
 </html>

--- a/src/renderer-require.js
+++ b/src/renderer-require.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import {AsyncSubject, Observable, Subject} from 'rx';
+import {fromRemoteWindow} from './remote-event';
 
 import {createProxyForRemote, executeJavaScriptMethod, executeJavaScriptMethodObservable, RecursiveProxyHandler} from './execute-js-func';
 
@@ -17,8 +18,7 @@ const BrowserWindow = process.type === 'renderer' ?
  * instead.
  *
  * @param  {string} modulePath  The path of the module to include.
- *
- * @return {Object}             Returns an Object with a `module` which is a Proxy
+ * * @return {Object}             Returns an Object with a `module` which is a Proxy
  *                              object, and a `dispose` method that will clean up
  *                              the window.
  */
@@ -26,10 +26,11 @@ export async function rendererRequireDirect(modulePath) {
   let bw = new BrowserWindow({width: 500, height: 500, show: false});
   let fullPath = require.resolve(modulePath);
 
-  let ready = new Promise((res,rej) => {
-    bw.webContents.once('did-finish-load', () => res(true));
-    bw.webContents.once('did-fail-load', (ev, errCode, errMsg) => rej(new Error(errMsg)));
-  });
+  let ready = Observable.merge(
+    fromRemoteWindow(bw, 'did-finish-load', true),
+    fromRemoteWindow(bw, 'did-fail-load', true)
+      .flatMap(([, , errMsg]) => Observable.throw(new Error(errMsg)))
+  ).take(1).toPromise();
 
   /* Uncomment for debugging!
   bw.show();

--- a/src/renderer-require.js
+++ b/src/renderer-require.js
@@ -5,7 +5,7 @@ import {createProxyForRemote, executeJavaScriptMethod, executeJavaScriptMethodOb
 
 import './custom-operators';
 
-const d = require('debug')('electron-remote:renderer-require');
+const d = require('debug-electron')('electron-remote:renderer-require');
 
 const BrowserWindow = process.type === 'renderer' ?
   require('electron').remote.BrowserWindow :

--- a/test/remote-event.js
+++ b/test/remote-event.js
@@ -3,7 +3,7 @@ import {fromRemoteWindow} from '../src/remote-event';
 
 const {BrowserWindow} = remote;
 
-describe.only('fromRemoteWindow', function() {
+describe('fromRemoteWindow', function() {
   this.timeout(10*1000);
   
   it('should get the ready-to-show event', async function() {

--- a/test/remote-event.js
+++ b/test/remote-event.js
@@ -1,0 +1,17 @@
+import {remote} from 'electron';
+import {fromRemoteWindow} from '../src/remote-event';
+
+const {BrowserWindow} = remote;
+
+describe('fromRemoteWindow', function() {
+  this.timeout(10*1000);
+  
+  it.only('should get the did-finish-load event', async function() {
+    let bw = new BrowserWindow({width: 500, height: 500, show: false});
+    
+    let finished = fromRemoteWindow(bw, 'did-finish-load').take(1).toPromise();
+    bw.loadURL('https://www.google.com');
+    
+    await finished;
+  });
+});

--- a/test/remote-event.js
+++ b/test/remote-event.js
@@ -3,15 +3,27 @@ import {fromRemoteWindow} from '../src/remote-event';
 
 const {BrowserWindow} = remote;
 
-describe('fromRemoteWindow', function() {
+describe.only('fromRemoteWindow', function() {
   this.timeout(10*1000);
   
-  it.only('should get the did-finish-load event', async function() {
+  it('should get the ready-to-show event', async function() {
     let bw = new BrowserWindow({width: 500, height: 500, show: false});
     
-    let finished = fromRemoteWindow(bw, 'did-finish-load').take(1).toPromise();
+    let finished = fromRemoteWindow(bw, 'ready-to-show').take(1).toPromise();
     bw.loadURL('https://www.google.com');
     
     await finished;
+    
+    bw.close();
+  });
+  
+  it('should get the dom-ready event', async function() {
+    let bw = new BrowserWindow({width: 500, height: 500, show: false});
+    
+    let finished = fromRemoteWindow(bw, 'dom-ready', true).take(1).toPromise();
+    bw.loadURL('https://www.google.com');
+    
+    await finished;
+    bw.close();
   });
 });


### PR DESCRIPTION
This PR adds a new method `fromRemoteWindow`:

```js
/**
 * Safely subscribes to an event on a BrowserWindow or its WebContents. This
 * method avoids the "remote event listener" Electron issue.
 *
 * @param browserWindow  BrowserWindow   - the window to listen to
 * @param event  String  - The event to listen to
 * @param onWebContents  Boolean  - If true, the event is on the window's
 *                                  WebContents, not on the window itself.
 * 
 * @returns Observable<Object>  - an Observable representing the event. 
 *                                Unsubscribing from the Observable will
 *                                remove the event listener.
 */
function fromRemoteWindow(browserWindow, event, onWebContents=false)
```

This PR also sets `remote-require` to use this method when creating BrowserWindows