### PR TITLE
Don't ignore onWebContents in the main process

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "doc": "esdoc -c ./esdoc.json",
     "compile": "git clean -xdf ./lib && babel -d lib/ src/ && cp ./src/*.html ./lib/",
     "prepublish": "npm run compile",
-    "test": "electron-mocha --renderer --require ./test/support.js ./test",
+    "test-renderer": "electron-mocha --renderer --require ./test/support.js ./test",
+    "test-browser": "electron-mocha --require ./test/support.js ./test/renderer-require",
+    "test": "npm run test-renderer && npm run test-browser",
     "node": "cross-env ELECTRON_RUN_AS_NODE=1 ./node_modules/electron-prebuilt-compile/node_modules/.bin/electron"
   },
   "repository": {

--- a/src/remote-event.js
+++ b/src/remote-event.js
@@ -24,38 +24,40 @@ const d = require('debug-electron')('remote-event');
  */
 export function fromRemoteWindow(browserWindow, event, onWebContents=false) {
   if (isBrowser) {
-    return Observable.fromEvent(browserWindow, event, (...args) => args);
+    return onWebContents ?
+      Observable.fromEvent(browserWindow.webContents, event, (...args) => args) :
+      Observable.fromEvent(browserWindow, event, (...args) => args);
   }
-  
+
   let type = 'window';
   let id = browserWindow.id;
-  
+
   const key = `electron-remote-event-${type}-${id}-${event}-${remote.getCurrentWebContents().id}`;
-  
+
   d(`Subscribing to event with key: ${key}`);
   let {error} = ipcRenderer.sendSync(
-    'electron-remote-event-subscribe', 
+    'electron-remote-event-subscribe',
     {type, id, event, onWebContents});
-  
+
   if (error) {
     d(`Failed with error: ${error}`);
     return Observable.throw(new Error(error));
   }
-  
+
   let ret = Observable.create((subj) => {
     let disp = new CompositeDisposable();
     disp.add(
       Observable.fromEvent(ipcRenderer, key, (e,arg) => arg)
         .do(() => d(`Got event: ${key}`))
         .subscribe(subj));
-      
+
     disp.add(Disposable.create(() => {
       d(`Got event: ${key}`);
       ipcRenderer.send('electron-remote-event-dispose', key);
     }));
-    
+
     return disp;
   });
-  
+
   return ret.publish().refCount();
 }

--- a/src/renderer-require.js
+++ b/src/renderer-require.js
@@ -8,9 +8,11 @@ import './custom-operators';
 
 const d = require('debug-electron')('electron-remote:renderer-require');
 
-const BrowserWindow = process.type === 'renderer' ?
-  require('electron').remote.BrowserWindow :
-  require('electron').BrowserWindow;
+const isBrowser = process.type === 'browser';
+
+const BrowserWindow = isBrowser ?
+  require('electron').BrowserWindow:
+  require('electron').remote.BrowserWindow;
 
 /**
  * Creates a BrowserWindow, requires a module in it, then returns a Proxy
@@ -26,11 +28,9 @@ export async function rendererRequireDirect(modulePath) {
   let bw = new BrowserWindow({width: 500, height: 500, show: false});
   let fullPath = require.resolve(modulePath);
 
-  let ready = Observable.merge(
-    fromRemoteWindow(bw, 'did-finish-load', true),
-    fromRemoteWindow(bw, 'did-fail-load', true)
-      .flatMap(([, , errMsg]) => Observable.throw(new Error(errMsg)))
-  ).take(1).toPromise();
+  let ready = isBrowser ?
+    windowIsReady(bw) :
+    remoteWindowIsReady(bw);
 
   /* Uncomment for debugging!
   bw.show();
@@ -53,6 +53,21 @@ export async function rendererRequireDirect(modulePath) {
     executeJavaScriptMethodObservable: (chain, ...args) => executeJavaScriptMethodObservable(bw, 240*1000, chain, ...args),
     dispose: () => bw.close()
   };
+}
+
+function windowIsReady(bw) {
+  return new Promise((res,rej) => {
+    bw.webContents.once('did-finish-load', () => res(true));
+    bw.webContents.once('did-fail-load', (ev, errCode, errMsg) => rej(new Error(errMsg)));
+  });
+}
+
+function remoteWindowIsReady(bw) {
+  return Observable.merge(
+    fromRemoteWindow(bw, 'did-finish-load', true),
+    fromRemoteWindow(bw, 'did-fail-load', true)
+      .flatMap(([, , errMsg]) => Observable.throw(new Error(errMsg)))
+    ).take(1).toPromise();
 }
 
 /**


### PR DESCRIPTION
This PR includes a test for `renderer-require` in the main process, and fixes the hang when we try to jump through too many hoops. We were just skipping `onWebContents` when `fromRemoteWindow` was called in the main process.