### PR TITLE
Generate unique IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "debug": "^2.2.0",
     "debug-electron": "^0.0.2",
+    "hashids": "^1.1.1",
     "pify": "^2.3.0",
     "rxjs": "^5.0.0-beta.12",
     "xmlhttprequest": "^1.8.0"

--- a/src/execute-js-func.js
+++ b/src/execute-js-func.js
@@ -25,7 +25,7 @@ const BrowserWindow = isBrowser ?
 
 let nextId = 1;
 function getNextId() {
-  return (process.pid << 32) | (nextId++);
+  return (process.pid << 32) ^ (nextId++);
 }
 
 /**

--- a/src/execute-js-func.js
+++ b/src/execute-js-func.js
@@ -1,5 +1,6 @@
 import {Observable} from 'rxjs/Observable';
 import {Subscription} from 'rxjs/Subscription';
+import Hashids from 'hashids';
 
 import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/throw';
@@ -24,8 +25,10 @@ const BrowserWindow = isBrowser ?
   require('electron').remote.BrowserWindow;
 
 let nextId = 1;
+const hashIds = new Hashids();
+
 function getNextId() {
-  return (process.pid << 32) ^ (nextId++);
+  return hashIds.encode(process.pid, nextId++);
 }
 
 /**


### PR DESCRIPTION
Bitwise OR will result in duplicate IDs whenever the bits line up with `process.pid`. For example:

```
pid << 32 = 9861   0010 0110 1000 0101
nextId = 4         0000 0000 0000 0100
OR                 -------------------
9861               0010 0110 1000 0101
```
```
pid << 32 = 9861   0010 0110 1000 0101
nextId = 5         0000 0000 0000 0101
OR                 -------------------
9861               0010 0110 1000 0101
```
❌ **Duplicate!**

Instead we'll just pass both the `pid` and the monotonic-int ID to [`Hashids`](http://hashids.org/), to give us a unique ID across all processes.